### PR TITLE
Feature/#37

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,7 @@ subprojects {
         implementation 'org.springframework.boot:spring-boot-starter-webflux'
         implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
+        runtimeOnly 'com.h2database:h2'
         compileOnly "org.projectlombok:lombok"
         annotationProcessor "org.projectlombok:lombok"
         testCompileOnly "org.projectlombok:lombok"

--- a/dongchimi-consumer/build.gradle
+++ b/dongchimi-consumer/build.gradle
@@ -1,6 +1,4 @@
 dependencies {
     implementation project(':dongchimi-party-domain')
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/dongchimi-consumer/src/main/java/com/dcm/global/config/RedisConfig.java
+++ b/dongchimi-consumer/src/main/java/com/dcm/global/config/RedisConfig.java
@@ -1,6 +1,5 @@
 package com.dcm.global.config;
 
-import com.dcm.global.constant.MessageConstant;
 import com.dcm.message.consumer.RedisConsumer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -12,12 +11,14 @@ import org.springframework.data.redis.listener.adapter.MessageListenerAdapter;
 @Configuration
 public class RedisConfig {
 
+    public static final String SUBSCRIBE_PREFIX = "/sub/room-";
+
     @Bean
     public RedisMessageListenerContainer redisContainer(RedisConnectionFactory connectionFactory,
                                                         RedisConsumer consumer) {
         RedisMessageListenerContainer container = new RedisMessageListenerContainer();
         container.setConnectionFactory(connectionFactory);
-        container.addMessageListener(listenerAdapter(consumer), new PatternTopic(MessageConstant.SUBSCRIBE_PREFIX + "*"));
+        container.addMessageListener(listenerAdapter(consumer), new PatternTopic(SUBSCRIBE_PREFIX + "*"));
         return container;
     }
 

--- a/dongchimi-consumer/src/main/java/com/dcm/global/constant/MessageConstant.java
+++ b/dongchimi-consumer/src/main/java/com/dcm/global/constant/MessageConstant.java
@@ -1,7 +1,0 @@
-package com.dcm.global.constant;
-
-public class MessageConstant {
-
-    public static final String SUBSCRIBE_PREFIX = "/sub/room-";
-
-}

--- a/dongchimi-consumer/src/main/java/com/dcm/message/consumer/RedisConsumer.java
+++ b/dongchimi-consumer/src/main/java/com/dcm/message/consumer/RedisConsumer.java
@@ -1,5 +1,6 @@
 package com.dcm.message.consumer;
 
+import com.dcm.chat.service.ChatService;
 import com.dcm.message.dto.MessageRequest;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
@@ -16,14 +17,14 @@ public class RedisConsumer implements MessageListener {
 
     private final RedisTemplate<String, String> redisTemplate;
     private final ObjectMapper objectMapper;
+    private final ChatService chatService;
 
     @Override
     public void onMessage(Message message, byte[] pattern) {
         try {
             String pubMessage = redisTemplate.getStringSerializer().deserialize(message.getBody());
             MessageRequest messageRequest = objectMapper.readValue(pubMessage, MessageRequest.class);
-
-            // TODO message 정보 저장
+            chatService.createChatMessage(messageRequest.chatId(), messageRequest.email(), messageRequest.message());
         } catch (Exception e) {
             log.warn(e.getMessage(), e);
         }

--- a/dongchimi-party-domain/build.gradle
+++ b/dongchimi-party-domain/build.gradle
@@ -1,7 +1,3 @@
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-
-    runtimeOnly 'com.h2database:h2'
-
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/dongchimi-party-domain/src/main/java/com/dcm/chat/domain/Chat.java
+++ b/dongchimi-party-domain/src/main/java/com/dcm/chat/domain/Chat.java
@@ -13,7 +13,6 @@ import java.util.List;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Getter
 @Table(name = "CHAT")
 public class Chat extends BaseEntity {
 

--- a/dongchimi-party-domain/src/main/java/com/dcm/chat/domain/ChatMessage.java
+++ b/dongchimi-party-domain/src/main/java/com/dcm/chat/domain/ChatMessage.java
@@ -12,10 +12,7 @@ public class ChatMessage extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long messageId;
-
-    @Column(nullable = false)
-    private Long partyId;
+    private Long chatMessageId;
 
     @Column(nullable = false)
     private String email;
@@ -23,8 +20,14 @@ public class ChatMessage extends BaseEntity {
     @Column(nullable = false, length = 200)
     private String message;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "chatId")
     private Chat chat;
+
+    public ChatMessage(String email, String message, Chat chat) {
+        this.email = email;
+        this.message = message;
+        this.chat = chat;
+    }
 
 }

--- a/dongchimi-party-domain/src/main/java/com/dcm/chat/exception/NotFoundChatException.java
+++ b/dongchimi-party-domain/src/main/java/com/dcm/chat/exception/NotFoundChatException.java
@@ -1,0 +1,8 @@
+package com.dcm.chat.exception;
+
+public class NotFoundChatException extends RuntimeException {
+
+    public NotFoundChatException(Long chatId) {
+        super(String.format("[Chat ID: %s] chat is not found", chatId));
+    }
+}

--- a/dongchimi-party-domain/src/main/java/com/dcm/chat/service/ChatService.java
+++ b/dongchimi-party-domain/src/main/java/com/dcm/chat/service/ChatService.java
@@ -1,12 +1,30 @@
 package com.dcm.chat.service;
 
+import com.dcm.chat.domain.Chat;
+import com.dcm.chat.domain.ChatMessage;
+import com.dcm.chat.exception.NotFoundChatException;
+import com.dcm.chat.domain.repository.ChatMessageRepository;
 import com.dcm.chat.domain.repository.ChatRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class ChatService {
 
     private final ChatRepository chatRepository;
+    private final ChatMessageRepository chatMessageRepository;
+
+    @Transactional
+    public void createChatMessage(Long chatId, String email, String message) {
+        Chat chat = readChat(chatId);
+        ChatMessage chatMessage = new ChatMessage(email, message, chat);
+        chatMessageRepository.save(chatMessage);
+    }
+
+    public Chat readChat(Long chatId) {
+        return chatRepository.findById(chatId).orElseThrow(() -> new NotFoundChatException(chatId));
+    }
 }

--- a/dongchimi-party-domain/src/main/java/com/dcm/global/config/JpaAuditingConfiguration.java
+++ b/dongchimi-party-domain/src/main/java/com/dcm/global/config/JpaAuditingConfiguration.java
@@ -1,0 +1,9 @@
+package com.dcm.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfiguration {
+}

--- a/dongchimi-party-domain/src/main/java/com/dcm/global/exception/ErrorResponse.java
+++ b/dongchimi-party-domain/src/main/java/com/dcm/global/exception/ErrorResponse.java
@@ -1,0 +1,5 @@
+package com.dcm.global.exception;
+
+public record ErrorResponse(String message) {
+
+}

--- a/dongchimi-party-domain/src/main/java/com/dcm/global/exception/GlobalExceptionHandler.java
+++ b/dongchimi-party-domain/src/main/java/com/dcm/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,29 @@
+package com.dcm.global.exception;
+
+import com.dcm.chat.exception.NotFoundChatException;
+import com.dcm.hobby.exception.NotFoundHobbyException;
+import com.dcm.hobbydetail.exception.NotFoundHobbyDetailException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+@Slf4j
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler({
+        NotFoundChatException.class,
+        NotFoundHobbyException.class,
+        NotFoundHobbyDetailException.class
+    })
+    public ResponseEntity<ErrorResponse> handleNotfoundException(RuntimeException exception) {
+        String message = exception.getMessage();
+        log.warn(message, exception);
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(new ErrorResponse(message));
+    }
+
+
+}

--- a/dongchimi-party-domain/src/test/java/com/dcm/chat/service/ChatServiceTest.java
+++ b/dongchimi-party-domain/src/test/java/com/dcm/chat/service/ChatServiceTest.java
@@ -1,0 +1,47 @@
+package com.dcm.chat.service;
+
+import com.dcm.chat.domain.Chat;
+import com.dcm.chat.domain.ChatMessage;
+import com.dcm.chat.domain.repository.ChatMessageRepository;
+import com.dcm.chat.domain.repository.ChatRepository;
+import com.dcm.common.ServiceTest;
+import com.dcm.fixtures.PartyFixtures;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+public class ChatServiceTest extends ServiceTest {
+
+    @Mock
+    private ChatRepository chatRepository;
+
+    @Mock
+    private ChatMessageRepository chatMessageRepository;
+
+    @InjectMocks
+    private ChatService chatService;
+
+    @DisplayName("성공적으로 채팅 메세지를 저장한다.")
+    @Test
+    void successChatMessage() {
+        // given
+        Optional<Chat> chat = Optional.of(PartyFixtures.CREATE_CHAT());
+        ChatMessage chatMessage = PartyFixtures.CREATE_CHAT_MESSAGE();
+
+        // when
+        doReturn(chat).when(chatRepository).findById(any(Long.class));
+        doReturn(chatMessage).when(chatMessageRepository).save(any(ChatMessage.class));
+        chatService.createChatMessage(PartyFixtures.CHAT_ID, PartyFixtures.EMAIL, PartyFixtures.MESSAGE);
+
+        // then
+        verify(chatRepository, times(1)).findById(any(Long.class));
+        verify(chatMessageRepository, times(1)).save(any(ChatMessage.class));
+    }
+
+}

--- a/dongchimi-party-domain/src/test/java/com/dcm/common/ControllerTest.java
+++ b/dongchimi-party-domain/src/test/java/com/dcm/common/ControllerTest.java
@@ -1,0 +1,10 @@
+package com.dcm.common;
+
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.test.context.ActiveProfiles;
+
+@AutoConfigureRestDocs
+@ActiveProfiles("test")
+public class ControllerTest {
+
+}

--- a/dongchimi-party-domain/src/test/java/com/dcm/common/RepositoryTest.java
+++ b/dongchimi-party-domain/src/test/java/com/dcm/common/RepositoryTest.java
@@ -1,0 +1,12 @@
+package com.dcm.common;
+
+import com.dcm.global.config.JpaAuditingConfiguration;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@Import(JpaAuditingConfiguration.class)
+public class RepositoryTest {
+}

--- a/dongchimi-party-domain/src/test/java/com/dcm/common/ServiceTest.java
+++ b/dongchimi-party-domain/src/test/java/com/dcm/common/ServiceTest.java
@@ -1,0 +1,9 @@
+package com.dcm.common;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("test")
+public class ServiceTest {
+}

--- a/dongchimi-party-domain/src/test/java/com/dcm/fixtures/PartyFixtures.java
+++ b/dongchimi-party-domain/src/test/java/com/dcm/fixtures/PartyFixtures.java
@@ -1,0 +1,61 @@
+package com.dcm.fixtures;
+
+import com.dcm.chat.domain.Chat;
+import com.dcm.chat.domain.ChatMessage;
+import com.dcm.global.enumurate.YN;
+import com.dcm.hobby.domain.Hobby;
+import com.dcm.party.domain.Party;
+import com.dcm.party.dto.PartyRequest;
+
+import static com.dcm.global.enumurate.YN.Y;
+
+public class PartyFixtures {
+
+    public static final YN USE_YN = Y;
+
+    // TODO Hobby
+    public static final Long HOBBY_ID = 1L;
+    public static final String HOBBY_NAME = "운동/스포츠";
+
+    // TODO Party
+    public static final Long PARTY_ID = 1L;
+    public static final String MANAGER_ID = "test@tset.com";
+    public static final String PARTY_NAME = "강서풋살";
+    public static final Integer CAPACITY = 100;
+    public static final String MEET_ADDRESS = "37.402105,-122.081974";
+    public static final String MEET_ADDRESS_NAME = "서울시 강서구";
+    public static final String DESCRIPTION = "풋살모임입니다";
+    public static final Long VOTE = 0L;
+
+
+    // TODO Chat
+    public static final Long CHAT_ID = 1L;
+
+    // TODO Chat Message
+    public static final Long CHAT_MESSAGE_ID = 1L;
+    public static final String EMAIL = "test@test.com";
+    public static final String MESSAGE = "Hi";
+
+    public static Hobby CREATE_HOBBY() {
+        return Hobby.of(HOBBY_ID, HOBBY_NAME, USE_YN);
+    }
+
+    public static Party CREATE_PARTY() {
+        return new Party(PARTY_ID, MANAGER_ID, PARTY_NAME, CAPACITY, MEET_ADDRESS,
+                MEET_ADDRESS_NAME, DESCRIPTION, VOTE, CREATE_HOBBY());
+    }
+
+    public static PartyRequest CREATE_PARTY_REQUEST() {
+        return new PartyRequest(MANAGER_ID, PARTY_NAME, CAPACITY, MEET_ADDRESS,
+                MEET_ADDRESS_NAME, DESCRIPTION, HOBBY_ID);
+    }
+
+    public static Chat CREATE_CHAT() {
+        return new Chat(CHAT_ID, USE_YN, CREATE_PARTY());
+    }
+
+    public static ChatMessage CREATE_CHAT_MESSAGE() {
+        return new ChatMessage(EMAIL, MESSAGE, CREATE_CHAT());
+    }
+
+}

--- a/dongchimi-party-domain/src/test/java/com/dcm/party/repository/PartyRepositoryTest.java
+++ b/dongchimi-party-domain/src/test/java/com/dcm/party/repository/PartyRepositoryTest.java
@@ -1,20 +1,19 @@
 package com.dcm.party.repository;
 
+import com.dcm.common.RepositoryTest;
 import com.dcm.chat.domain.Chat;
 import com.dcm.chat.domain.repository.ChatRepository;
-import com.dcm.common.RepositoryTest;
+import com.dcm.fixtures.PartyFixtures;
 import com.dcm.hobby.domain.Hobby;
 import com.dcm.hobby.domain.repository.HobbyRepository;
 import com.dcm.party.domain.Party;
 import com.dcm.party.domain.repository.PartyRepository;
-import com.dcm.party.dto.PartyRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.Optional;
 
-import static com.dcm.global.enumurate.YN.Y;
 import static org.springframework.test.util.AssertionErrors.assertTrue;
 
 public class PartyRepositoryTest extends RepositoryTest {
@@ -32,24 +31,21 @@ public class PartyRepositoryTest extends RepositoryTest {
     @Test
     void successPartyAndChat() {
         // given
-        Hobby hobby = Hobby.of("운동/스포츠", Y);
-        hobbyRepository.save(hobby);
-        PartyRequest partyRequest = new PartyRequest("scnoh@test.com", "강서풋살", 100, "37.402105,-122.081974",
-                "서울시 강서구", "풋살모임입니다.", 1L);
-
-        Party party = Party.toEntity(partyRequest, hobby);
-        Chat chat = new Chat(party);
+        Hobby hobby = PartyFixtures.CREATE_HOBBY();
+        Party party = PartyFixtures.CREATE_PARTY();
+        Chat chat = PartyFixtures.CREATE_CHAT();
 
         // when
+        hobbyRepository.save(hobby);
         partyRepository.save(party);
         chatRepository.save(chat);
 
         // then
         Optional<Party> findGroup = partyRepository.findById(party.getPartyId());
-        assertTrue("그룹 생성에 실패하였습니다.", findGroup.isPresent());
+        assertTrue("그룹 생성에 성공하였습니다.", findGroup.isPresent());
 
         Optional<Chat> findChat = chatRepository.findById(chat.getChatId());
-        assertTrue("채팅방 생성에 실패하였습니다.", findChat.isPresent());
+        assertTrue("채팅방 생성에 성공하였습니다.", findChat.isPresent());
     }
 
 }

--- a/dongchimi-party-domain/src/test/java/com/dcm/party/service/PartyServiceTest.java
+++ b/dongchimi-party-domain/src/test/java/com/dcm/party/service/PartyServiceTest.java
@@ -1,8 +1,9 @@
 package com.dcm.party.service;
 
+import com.dcm.common.ServiceTest;
 import com.dcm.chat.domain.Chat;
 import com.dcm.chat.domain.repository.ChatRepository;
-import com.dcm.common.ServiceTest;
+import com.dcm.fixtures.PartyFixtures;
 import com.dcm.hobby.domain.Hobby;
 import com.dcm.hobby.domain.repository.HobbyRepository;
 import com.dcm.party.domain.Party;
@@ -15,8 +16,6 @@ import org.mockito.Mock;
 
 import java.util.Optional;
 
-import static com.dcm.global.enumurate.YN.N;
-import static com.dcm.global.enumurate.YN.Y;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
@@ -40,13 +39,10 @@ class PartyServiceTest extends ServiceTest {
     @Test
     void successPartyAndChat() {
         // given
-        Optional<Hobby> hobby = Optional.ofNullable(Hobby.of(1L, "운동/스포츠", Y));
-        Party party = new Party(1L, "scnoh@test.com", "강서풋살", 100, "37.402105,-122.081974",
-                "서울시 강서구", "풋살모임입니다.", 0L, hobby.get());
-
-        PartyRequest partyRequest = new PartyRequest("scnoh@test.com", "강서풋살", 100, "37.402105,-122.081974",
-                "서울시 강서구", "풋살모임입니다.", 1L);
-        Chat chat = new Chat(1L, N, party);
+        Optional<Hobby> hobby = Optional.ofNullable(PartyFixtures.CREATE_HOBBY());
+        PartyRequest partyRequest = PartyFixtures.CREATE_PARTY_REQUEST();
+        Party party = PartyFixtures.CREATE_PARTY();
+        Chat chat = PartyFixtures.CREATE_CHAT();
 
         // when
         doReturn(hobby).when(hobbyRepository).findById(any(Long.class));

--- a/dongchimi-party-domain/src/test/resources/application.yml
+++ b/dongchimi-party-domain/src/test/resources/application.yml
@@ -1,0 +1,27 @@
+spring:
+  profiles:
+    active: test
+
+  sql:
+    init:
+      mode: never
+      path: /h2-console
+
+  h2:
+    console:
+      enabled: true
+
+  datasource:
+    url: jdbc:h2:~/test
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+#    defer-datasource-initialization: true

--- a/dongchimi-reactive/build.gradle
+++ b/dongchimi-reactive/build.gradle
@@ -1,5 +1,4 @@
 dependencies {
-
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-integration'
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'

--- a/dongchimi-reactive/src/main/java/com/dcm/global/config/RedisConfig.java
+++ b/dongchimi-reactive/src/main/java/com/dcm/global/config/RedisConfig.java
@@ -1,6 +1,5 @@
 package com.dcm.global.config;
 
-import com.dcm.global.constant.MessageConstant;
 import com.dcm.message.consumer.RedisConsumer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -14,6 +13,8 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 public class RedisConfig {
+
+    public static final String SUBSCRIBE_PREFIX = "/sub/room-";
 
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
@@ -34,7 +35,7 @@ public class RedisConfig {
                                                         RedisConsumer consumer) {
         RedisMessageListenerContainer container = new RedisMessageListenerContainer();
         container.setConnectionFactory(connectionFactory);
-        container.addMessageListener(listenerAdapter(consumer), new PatternTopic(MessageConstant.SUBSCRIBE_PREFIX + "*"));
+        container.addMessageListener(listenerAdapter(consumer), new PatternTopic(SUBSCRIBE_PREFIX + "*"));
         return container;
     }
 

--- a/dongchimi-reactive/src/main/java/com/dcm/global/constant/MessageConstant.java
+++ b/dongchimi-reactive/src/main/java/com/dcm/global/constant/MessageConstant.java
@@ -1,7 +1,0 @@
-package com.dcm.global.constant;
-
-public class MessageConstant {
-
-    public static final String SUBSCRIBE_PREFIX = "/sub/room-";
-
-}

--- a/dongchimi-reactive/src/main/java/com/dcm/global/serializer/RedisSerializer.java
+++ b/dongchimi-reactive/src/main/java/com/dcm/global/serializer/RedisSerializer.java
@@ -1,0 +1,17 @@
+package com.dcm.global.serializer;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RedisSerializer implements Serializer {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    @Override
+    public Object deserialize(byte[] bytes) {
+        return redisTemplate.getStringSerializer().deserialize(bytes);
+    }
+}

--- a/dongchimi-reactive/src/main/java/com/dcm/global/serializer/Serializer.java
+++ b/dongchimi-reactive/src/main/java/com/dcm/global/serializer/Serializer.java
@@ -1,0 +1,9 @@
+package com.dcm.global.serializer;
+
+import org.springframework.lang.Nullable;
+
+public interface Serializer<T> {
+
+    T deserialize(@Nullable byte[] bytes);
+
+}

--- a/dongchimi-reactive/src/main/java/com/dcm/message/consumer/RedisConsumer.java
+++ b/dongchimi-reactive/src/main/java/com/dcm/message/consumer/RedisConsumer.java
@@ -1,13 +1,13 @@
 package com.dcm.message.consumer;
 
 import com.dcm.global.config.RedisConfig;
+import com.dcm.global.serializer.Serializer;
 import com.dcm.message.dto.MessageRequest;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.connection.Message;
 import org.springframework.data.redis.connection.MessageListener;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.stereotype.Service;
 
@@ -16,14 +16,14 @@ import org.springframework.stereotype.Service;
 @Slf4j
 public class RedisConsumer implements MessageListener {
 
-    private final RedisTemplate<String, String> redisTemplate;
+    private final Serializer<String> serializer; // TODO 의존 타입에 대한 정의 필요
     private final SimpMessageSendingOperations messageSendingOperations;
     private final ObjectMapper objectMapper;
 
     @Override
     public void onMessage(Message message, byte[] pattern) {
         try {
-            String pubMessage = redisTemplate.getStringSerializer().deserialize(message.getBody());
+            String pubMessage = serializer.deserialize(message.getBody());
             MessageRequest messageRequest = objectMapper.readValue(pubMessage, MessageRequest.class);
 
             // TODO Client 구독자에게 Message 수신

--- a/dongchimi-reactive/src/main/java/com/dcm/message/consumer/RedisConsumer.java
+++ b/dongchimi-reactive/src/main/java/com/dcm/message/consumer/RedisConsumer.java
@@ -1,6 +1,6 @@
 package com.dcm.message.consumer;
 
-import com.dcm.global.constant.MessageConstant;
+import com.dcm.global.config.RedisConfig;
 import com.dcm.message.dto.MessageRequest;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
@@ -27,7 +27,7 @@ public class RedisConsumer implements MessageListener {
             MessageRequest messageRequest = objectMapper.readValue(pubMessage, MessageRequest.class);
 
             // TODO Client 구독자에게 Message 수신
-            messageSendingOperations.convertAndSend(MessageConstant.SUBSCRIBE_PREFIX + messageRequest.chatId(), messageRequest.message());
+            messageSendingOperations.convertAndSend(RedisConfig.SUBSCRIBE_PREFIX + messageRequest.chatId(), messageRequest.message());
         } catch (Exception e) {
             // TODO Exception Handler 통해 예외 처리
             log.warn(e.getMessage(), e);

--- a/dongchimi-reactive/src/main/java/com/dcm/message/publisher/RedisPublisher.java
+++ b/dongchimi-reactive/src/main/java/com/dcm/message/publisher/RedisPublisher.java
@@ -1,6 +1,6 @@
 package com.dcm.message.publisher;
 
-import com.dcm.global.constant.MessageConstant;
+import com.dcm.global.config.RedisConfig;
 import com.dcm.message.dto.MessageRequest;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -21,7 +21,7 @@ public class RedisPublisher implements MessagePublisher {
     public void publish(MessageRequest request) {
         try {
             String message = objectMapper.writeValueAsString(request);
-            redisTemplate.convertAndSend(MessageConstant.SUBSCRIBE_PREFIX + request.chatId(), message);
+            redisTemplate.convertAndSend(RedisConfig.SUBSCRIBE_PREFIX + request.chatId(), message);
         } catch (JsonProcessingException e) {
             // TODO Exception Handler 통해 예외 처리
             log.warn(e.getMessage(), e);


### PR DESCRIPTION
### 작업 내용
- RedisTemplate에 의존 되어 있던 RedisConsumer를 Serializer 인터페이스를 통해 Message를 deserialize 하도록 개선
- pub message를 RDB에 저장하는 로직 구현
- Redis Config 상수 위치 수정
- 공통 의존성 전역에서 설정하도록 수정 (H2, spring-test)
- Message 저장 Service layer 테스트 코드 작성  (Fixtures에서 Mock 데이터 가져다 사용 할 수 있도록 추가)