### PR TITLE
[feat] Reactive 모듈에서 메세지 전달 시 예외가 발생하면 Websocket 연결을 해제하지 않고 에러 응답을 보낼 수 있도록 구현

### DIFF
--- a/dongchimi-reactive/src/main/java/com/dcm/global/config/RedisConfig.java
+++ b/dongchimi-reactive/src/main/java/com/dcm/global/config/RedisConfig.java
@@ -16,6 +16,17 @@ public class RedisConfig {
 
     public static final String SUBSCRIBE_PREFIX = "/sub/room-";
 
+    /**
+     * Redis Connection Factory 특징
+     *  1. Jedis
+     *    - 멀티쓰레드환경에서 쓰레드 안전을 보장하지 않는다.
+     *    - Connection pool을 사용하여 성능, 안정성 개선이 가능하지만 Lettuce보다 상대적으로 하드웨어적인 자원이 많이 필요하다.
+     *    - 비동기 기능을 제공하지 않는다.
+     *
+     *  2. Lettuce - Netty 기반 redis client library
+     *    - 비동기로 요청하기 때문에 Jedis에 비해 높은 성능을 가지고 있다.
+     *    - TPS, 자원사용량 모두 Jedis에 비해 우수한 성능을 보인다는 테스트 사례가 있다.
+     * */
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
         return new LettuceConnectionFactory();

--- a/dongchimi-reactive/src/main/java/com/dcm/global/config/WebSocketConfig.java
+++ b/dongchimi-reactive/src/main/java/com/dcm/global/config/WebSocketConfig.java
@@ -1,5 +1,6 @@
 package com.dcm.global.config;
 
+import com.dcm.global.stomp.StompHandshakeHandler;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocket;
@@ -15,13 +16,14 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/ws")
-                .setAllowedOrigins("*");
+                .setAllowedOrigins("*")
+                .setHandshakeHandler(new StompHandshakeHandler());
     }
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry config) {
         config.setApplicationDestinationPrefixes("/pub");
-        config.enableSimpleBroker("/sub");
+        config.enableSimpleBroker("/sub", "/user");
     }
 
 }

--- a/dongchimi-reactive/src/main/java/com/dcm/global/exception/ErrorMessage.java
+++ b/dongchimi-reactive/src/main/java/com/dcm/global/exception/ErrorMessage.java
@@ -1,0 +1,3 @@
+package com.dcm.global.exception;
+
+public record ErrorMessage<T>(String message, T object) {}

--- a/dongchimi-reactive/src/main/java/com/dcm/global/exception/StompExceptionHandler.java
+++ b/dongchimi-reactive/src/main/java/com/dcm/global/exception/StompExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.dcm.global.exception;
 
+import com.dcm.global.stomp.StompPrincipal;
 import com.dcm.message.dto.MessageRequest;
 import com.dcm.message.exception.MessagePublishException;
 import lombok.RequiredArgsConstructor;
@@ -9,16 +10,6 @@ import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 
-import java.security.Principal;
-
-/**
- * ControllerAdvice의 annotation은 @ControllerAdvice @RestControllerAdvice 두가지가 있습니다. 예외 발생 시 json형태로 결과를 반환하려면
- * @RestControllerAdvice를 클래스에 선언하면 됩니다. 어노테이션에 추가로 패키지를 적용하면 위에서 설명한 것처럼 특정 패키지 하위의 Controller에만 로직이 적용되게도 할 수 있습니다.
- * ex) @RestControllerAdvice(basePackages = “com.dcm.message”)
- * 아무것도 적용하지 않으면 프로젝트의 모든 Controller에 로직이 적용됩니다.
- * 여기서는 STOMP 통신의 예외처리를 위해 @ControllerAdvice로 선언하여 @MessageExceptionHandler를 통해 STOMP 통신이 해제되지 않고,
- * 에러 응답을 전달 할 수 있도록 예외를 처리합니다.
- */
 @ControllerAdvice
 @RequiredArgsConstructor
 @Slf4j
@@ -27,7 +18,7 @@ public class StompExceptionHandler {
     private final SimpMessageSendingOperations messageTemplate;
 
     @MessageExceptionHandler(MessagePublishException.class)
-    public void handleMessagePublishException(Principal principal, MessagePublishException exception, @Payload MessageRequest request) {
+    public void handleMessagePublishException(StompPrincipal principal, MessagePublishException exception, @Payload MessageRequest request) {
         log.warn(exception.getMessage(), exception);
         ErrorMessage<MessageRequest> errorMessage = new ErrorMessage<>(exception.getMessage(), request);
         messageTemplate.convertAndSendToUser(principal.getName(), "/error", errorMessage);

--- a/dongchimi-reactive/src/main/java/com/dcm/global/exception/StompExceptionHandler.java
+++ b/dongchimi-reactive/src/main/java/com/dcm/global/exception/StompExceptionHandler.java
@@ -1,0 +1,36 @@
+package com.dcm.global.exception;
+
+import com.dcm.message.dto.MessageRequest;
+import com.dcm.message.exception.MessagePublishException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.handler.annotation.MessageExceptionHandler;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.simp.SimpMessageSendingOperations;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+
+import java.security.Principal;
+
+/**
+ * ControllerAdvice의 annotation은 @ControllerAdvice @RestControllerAdvice 두가지가 있습니다. 예외 발생 시 json형태로 결과를 반환하려면
+ * @RestControllerAdvice를 클래스에 선언하면 됩니다. 어노테이션에 추가로 패키지를 적용하면 위에서 설명한 것처럼 특정 패키지 하위의 Controller에만 로직이 적용되게도 할 수 있습니다.
+ * ex) @RestControllerAdvice(basePackages = “com.dcm.message”)
+ * 아무것도 적용하지 않으면 프로젝트의 모든 Controller에 로직이 적용됩니다.
+ * 여기서는 STOMP 통신의 예외처리를 위해 @ControllerAdvice로 선언하여 @MessageExceptionHandler를 통해 STOMP 통신이 해제되지 않고,
+ * 에러 응답을 전달 할 수 있도록 예외를 처리합니다.
+ */
+@ControllerAdvice
+@RequiredArgsConstructor
+@Slf4j
+public class StompExceptionHandler {
+
+    private final SimpMessageSendingOperations messageTemplate;
+
+    @MessageExceptionHandler(MessagePublishException.class)
+    public void handleMessagePublishException(Principal principal, MessagePublishException exception, @Payload MessageRequest request) {
+        log.warn(exception.getMessage(), exception);
+        ErrorMessage<MessageRequest> errorMessage = new ErrorMessage<>(exception.getMessage(), request);
+        messageTemplate.convertAndSendToUser(principal.getName(), "/error", errorMessage);
+    }
+
+}

--- a/dongchimi-reactive/src/main/java/com/dcm/global/stomp/StompHandshakeHandler.java
+++ b/dongchimi-reactive/src/main/java/com/dcm/global/stomp/StompHandshakeHandler.java
@@ -1,0 +1,21 @@
+package com.dcm.global.stomp;
+
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.server.support.DefaultHandshakeHandler;
+
+import java.security.Principal;
+import java.util.Map;
+import java.util.UUID;
+
+public class StompHandshakeHandler extends DefaultHandshakeHandler {
+
+    /**
+     * Websocket의 사용자를 식별을 결정하기 위해 재정의 할 수 있는 메서드. 이 메서드를 재정의하는 것은 Websocket을 연결할 때
+     * 사용자 식별자인 Principla을 제공받는데, 이 식별자를 UUID로 지정하여 Websocket 연결 시 사용자에게 부여할 수 있도록 정의.
+     */
+    @Override
+    protected Principal determineUser(ServerHttpRequest request, WebSocketHandler wsHandler, Map<String, Object> attributes) {
+        return new StompPrincipal(UUID.randomUUID().toString());
+    }
+}

--- a/dongchimi-reactive/src/main/java/com/dcm/global/stomp/StompPrincipal.java
+++ b/dongchimi-reactive/src/main/java/com/dcm/global/stomp/StompPrincipal.java
@@ -1,0 +1,17 @@
+package com.dcm.global.stomp;
+
+import java.security.Principal;
+
+public class StompPrincipal implements Principal {
+
+    private String name;
+
+    public StompPrincipal(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+}

--- a/dongchimi-reactive/src/main/java/com/dcm/global/stomp/StompPrincipal.java
+++ b/dongchimi-reactive/src/main/java/com/dcm/global/stomp/StompPrincipal.java
@@ -2,9 +2,8 @@ package com.dcm.global.stomp;
 
 import java.security.Principal;
 
-public class StompPrincipal implements Principal {
 
-    private String name;
+public record StompPrincipal(String name) implements Principal {
 
     public StompPrincipal(String name) {
         this.name = name;

--- a/dongchimi-reactive/src/main/java/com/dcm/message/exception/MessagePublishException.java
+++ b/dongchimi-reactive/src/main/java/com/dcm/message/exception/MessagePublishException.java
@@ -1,0 +1,9 @@
+package com.dcm.message.exception;
+
+public class MessagePublishException extends RuntimeException {
+
+    public MessagePublishException(String message) {
+        super(message);
+    }
+
+}

--- a/dongchimi-reactive/src/main/java/com/dcm/message/publisher/RedisPublisher.java
+++ b/dongchimi-reactive/src/main/java/com/dcm/message/publisher/RedisPublisher.java
@@ -2,6 +2,7 @@ package com.dcm.message.publisher;
 
 import com.dcm.global.config.RedisConfig;
 import com.dcm.message.dto.MessageRequest;
+import com.dcm.message.exception.MessagePublishException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
@@ -24,7 +25,7 @@ public class RedisPublisher implements MessagePublisher {
             redisTemplate.convertAndSend(RedisConfig.SUBSCRIBE_PREFIX + request.chatId(), message);
         } catch (JsonProcessingException e) {
             // TODO Exception Handler 통해 예외 처리
-            log.warn(e.getMessage(), e);
+            throw new MessagePublishException(e.getMessage());
         }
     }
 


### PR DESCRIPTION
### 작업 내용
- STOMP 통신에서 사용자가 메세지를 전송 시 예외가 발생한 경우 에러 응답을 전달할 수 있도록 MessgaeExceptionHandler 구현
- 예외 발생 후 에러 응답을 전달할 때 모든 사용자에게 브로드캐스팅 하지 않고 요청 보낸 사용자에게만 전달 할 수 있도록 Principal를 재정의하여 사용자 식별 할 수 있게 UUID 부여